### PR TITLE
GH-15: Made `unstage` a bit more flexible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dugite-extra",
-    "version": "0.0.1-alpha.22",
+    "version": "0.0.1-alpha.23",
     "description": "High-level Git commands for dugite.",
     "main": "lib/index",
     "typings": "lib/index",

--- a/src/command/stage.ts
+++ b/src/command/stage.ts
@@ -7,10 +7,15 @@ import { WorkingDirectoryFileChange } from '../model/status';
  * Add the given files to the index, stages the files.
  *
  * @param repository the repository path to the local Git clone.
- * @param filePaths the absolute FS path of the files to stage.
+ * @param filePaths the absolute FS path of the files to stage. If not specified, or an empty array, the it stages all changes.
  */
-export async function stage(repositoryPath: string, filePaths: string | string[]): Promise<void> {
-    const paths = (Array.isArray(filePaths) ? filePaths : [filePaths]).map(f => path.relative(repositoryPath, f));
+export async function stage(repositoryPath: string, filePaths?: string | string[]): Promise<void> {
+    const paths: string[] = [];
+    if (filePaths === undefined || (Array.isArray(filePaths) && filePaths.length === 0)) {
+        paths.push('.');
+    } else {
+        paths.push(...(Array.isArray(filePaths) ? filePaths : [filePaths]).map(f => path.relative(repositoryPath, f)));
+    }
     await git(['add', ...paths], repositoryPath, 'stage');
 }
 
@@ -18,11 +23,37 @@ export async function stage(repositoryPath: string, filePaths: string | string[]
  * Removes the given files from the index. In other words, unstages the files.
  *
  * @param repository the repository path to the local Git clone.
- * @param filePaths the absolute FS path of the files to unstage.
+ * @param filePaths the absolute FS path of the files to unstage. If not specified, or an empty array, is resets everything.
+ * @param treeish the treeish to reset to. If not specified, then `HEAD` will be used.
+ * @param where `index` to reset the index state, `working-tree` to reset the working tree but keep the index state. `all` to perform a hard reset. `all` be default.
  */
-export async function unstage(repositoryPath: string, filePaths: string | string[]): Promise<void> {
-    const paths = (Array.isArray(filePaths) ? filePaths : [filePaths]).map(f => path.relative(repositoryPath, f));
-    await git(['reset', '--', ...paths], repositoryPath, 'unstage');
+export async function unstage(repositoryPath: string, filePaths?: string | string[], treeish?: string, where?: 'index' | 'working-tree' | 'all'): Promise<void> {
+    const _treeish = treeish || 'HEAD';
+    const _where = where || 'all';
+    const branch = await git(['branch'], repositoryPath, 'branch');
+    const args: string[] = [];
+    // Detached HEAD.
+    if (!branch.stdout.trim()) {
+        args.push(...['rm', '--cached', '-r', '--']);
+    } else {
+        if (_where === 'working-tree') {
+            args.push(...['checkout-index', '-f']);
+        } else {
+            args.push('reset');
+            if (_where === 'index') {
+                args.push('-q');
+            }
+        }
+        args.push(...[_treeish, '--']);
+    }
+    const paths: string[] = [];
+    if (filePaths === undefined || (Array.isArray(filePaths) && filePaths.length === 0)) {
+        paths.push('.');
+    } else {
+        paths.push(...(Array.isArray(filePaths) ? filePaths : [filePaths]).map(f => path.relative(repositoryPath, f)));
+    }
+    args.push(...paths);
+    await git(args, repositoryPath, 'unstage');
 }
 
 /**


### PR DESCRIPTION
 - One can reset the index and the working tree state [`git reset`].
 - Reset the index state but keep the working tree [`git reset -q`].
 - Reset the working tree but keep the index [`git checkout-index`].
 - Call `rm cached` when in detached mode.

Closes #15.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>