### PR TITLE
Changed command to create a new branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite-extra",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "High-level Git commands for dugite.",
   "main": "lib/index",
   "typings": "lib/index",

--- a/src/command/branch.spec.ts
+++ b/src/command/branch.spec.ts
@@ -1,0 +1,91 @@
+import * as temp from 'temp';
+import * as fs from 'fs-extra';
+import *  as Path from 'path';
+import { expect } from 'chai';
+import { createCommit } from './commit';
+import { initRepository } from './test-helper';
+import { git } from '../core/git';
+import { listBranch, createBranch } from './branch';
+
+const track = temp.track();
+
+let path: string;
+
+const createAndCommit = async(filename: string, message: string): Promise<void> =>  {
+    fs.createFileSync(Path.join(path, filename));
+
+    await git(['add', '.'], path, 'add');
+    await createCommit(path, message);
+}
+
+describe('branch', async () => {
+
+    beforeEach(async () => {
+        path = track.mkdirSync('branch');
+        await initRepository(path);
+    });
+
+    afterEach(async () => {
+        await track.cleanup();
+    });
+
+    it('no branch before first commit', async () => {
+        const localBranches = await listBranch(path, 'all');
+        expect(localBranches.length).to.be.equal(0);
+
+        const currentBranch = await listBranch(path, 'current');
+        expect(currentBranch).to.be.undefined;
+    });
+
+    it('only master branch after first commit', async () => {
+        await createAndCommit('some-file.txt', 'first commit');
+
+        const localBranches = await listBranch(path, 'all');
+        expect(localBranches.length).to.be.equal(1);
+        expect(localBranches[0].name).to.be.equal('master');
+
+        const curretnBranch = await listBranch(path, 'current');
+        expect(curretnBranch).to.not.be.undefined;
+        expect(curretnBranch!.name).to.be.equal('master');
+    });
+
+    it('new branch is selected on creation', async () => {
+        await createAndCommit('some-file.txt', 'first commit');
+
+        const newBranch = 'branch1';
+        await createBranch(path, newBranch);
+
+        const localBranches = await listBranch(path, 'all');
+        expect(localBranches.length).to.be.equal(2);
+        expect(localBranches[0].name).to.be.equal('master');
+        expect(localBranches[1].name).to.be.equal(newBranch);
+
+        const currentBranch = await listBranch(path, 'current');
+        expect(currentBranch).to.not.be.undefined;
+        expect(currentBranch!.name).to.be.equal(newBranch);
+    });
+
+    it('new branch is not created until first commit', async () => {
+        const newBranch = 'branch1';
+        await createBranch(path, newBranch);
+
+        const localBranches = await listBranch(path, 'all');
+        expect(localBranches.length).to.be.equal(0);
+    });
+
+    it('new branch is created on first commit in place of master', async () => {
+        const newBranch = 'branch1';
+        await createBranch(path, newBranch);
+
+        await createAndCommit('some-file.txt', 'first commit');
+
+        const localBranches = await listBranch(path, 'all');
+        expect(localBranches.length).to.be.equal(1);
+        expect(localBranches[0].name).to.be.equal(newBranch);
+
+        const currentBranch = await listBranch(path, 'current');
+        expect(currentBranch).to.not.be.undefined;
+        expect(currentBranch!.name).to.be.equal(newBranch);
+    });
+
+});

--- a/src/command/branch.spec.ts
+++ b/src/command/branch.spec.ts
@@ -25,8 +25,8 @@ describe('branch', async () => {
         await initRepository(path);
     });
 
-    afterEach(async () => {
-        await track.cleanup();
+    afterEach((done: ((err: any, result: temp.Stats) => void)) => {
+        track.cleanup(done);
     });
 
     it('no branch before first commit', async () => {

--- a/src/command/branch.ts
+++ b/src/command/branch.ts
@@ -51,9 +51,15 @@ export async function listBranch(repositoryPath: string, type: 'current' | 'loca
     }
 }
 
-export async function createBranch(repositoryPath: string, name: string, createOptions?: { startPoint?: string }, options?: IGitExecutionOptions): Promise<void> {
+export async function createBranch(
+    repositoryPath: string,
+    name: string,
+    createOptions?: { startPoint?: string, checkout?: boolean },
+    options?: IGitExecutionOptions): Promise<void> {
+
     const startPoint = createOptions ? createOptions.startPoint : undefined;
-    const args = ['checkout', '-b', name];
+    const checkout = createOptions ? createOptions.checkout : false;
+    const args = checkout ? ['checkout', '-b', name] : ['branch', name];
     if (startPoint) {
         args.push(startPoint);
     }

--- a/src/command/branch.ts
+++ b/src/command/branch.ts
@@ -53,7 +53,7 @@ export async function listBranch(repositoryPath: string, type: 'current' | 'loca
 
 export async function createBranch(repositoryPath: string, name: string, createOptions?: { startPoint?: string }, options?: IGitExecutionOptions): Promise<void> {
     const startPoint = createOptions ? createOptions.startPoint : undefined;
-    const args = ['branch', name];
+    const args = ['checkout', '-b', name];
     if (startPoint) {
         args.push(startPoint);
     }


### PR DESCRIPTION
At the moment it is not possible to create a new branch on git if `master` doesn't already exist.

Changing the `git branch` command to `git checkout -b` makes this possible.

The drawback is that this is a potentially breaking change since `git checkout -b` also changes the active branch. This doesn't seem to be a problem in Theia, where the only place a branch is created, a checkout operation is also performed.