### PR TITLE
Bump version number to 0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dugite-extra",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "High-level Git commands for dugite.",
   "main": "lib/index",
   "typings": "lib/index",


### PR DESCRIPTION
After #57 has been merged, we should publish a new version npm.